### PR TITLE
style(search): add media query to stop overlapping (#14)

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -37,7 +37,7 @@
 }
 
 @media screen and (max-width: 400px) {
-    .searchBox_node_modules-\@docusaurus-theme-classic-lib-theme-Navbar-Search-styles-module {
-        right: 4rem !important;
+    .navbar__items--right > :last-child {
+        right: 4rem;
     }
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Added `right: 4rem` to the media query for `navbar__items` to prevent overlapping

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

-   [X] Bug fix
-   [ ] New Feature
-   [ ] Other

### Before submitting the PR, please make sure you do the following

-   [X] Read the [Contributing Guidelines](https://github.com/arclix/arclix-docs/blob/master/CONTRIBUTING.md).
-   [X] Read the [Pull Request Guidelines](https://github.com/arclix/arclix-docs/blob/master/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/arclix/arclix-docs/blob/master/.github/COMMIT_CONVENTION.md).
-   [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
-   [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
-   [ ] Ideally, include relevant tests that fail without this PR but pass with it.
