### PR TITLE
fix: add path caution to docs

### DIFF
--- a/docs/arclix-configuration/dynamic-component-types.md
+++ b/docs/arclix-configuration/dynamic-component-types.md
@@ -21,7 +21,7 @@ For example the user wants certain component like `pages` to have different conf
         },
         "pages": {
             "cssPreprocessor": "pcss",
-            "path": "src/pages"
+            "path": "./src/pages"
         }
     }
 }

--- a/docs/arclix-configuration/option.md
+++ b/docs/arclix-configuration/option.md
@@ -50,12 +50,16 @@ Our configurable `options` simplify CLI configuration, making it easier and more
 
     > **Note**: `./` is the default value for `path`.
 
+    :::caution
+    Only relative path is accepted by the `path` option. So using absolute path may lead to an unexpected error.
+    :::
+
 ### Override the options for generating a certain component
 
 You can `override` the options in `arclix.config.json`, if you want some `options` needed only for generating a certain component by adding the [flags](../component-generation/option#flags).
 
-For example: If you want `Contact` to go in `pages` folder but you have configured `path` in config file to `/src/components` then you can use `--path or -p` flag to `override` the `path` **temporarily** only for that component.
+For example: If you want `Contact` to go in `pages` folder but you have configured `path` in config file to `./src/components` then you can use `--path or -p` flag to `override` the `path` **temporarily** only for that component.
 
 ```bash
-npx arclix@latest g c Contact --path="/src/pages/"
+npx arclix@latest g c Contact --path="./src/pages"
 ```

--- a/docs/component-generation/option.md
+++ b/docs/component-generation/option.md
@@ -122,6 +122,10 @@ or
 npx arclix@latest generate component [COMPONENT NAME] -p <some path>
 ```
 
+:::caution
+Only relative path is accepted by the `path` flag. So using absolute path may lead to an unexpected error.
+:::
+
 #### Structure
 
 ```


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

- Updated all showcases of `path` to relative path.
- Added caution to not use absolute path

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

-   [X] Bug fix
-   [ ] New Feature
-   [ ] Other

### Before submitting the PR, please make sure you do the following

-   [X] Read the [Contributing Guidelines](https://github.com/arclix/arclix-docs/blob/master/CONTRIBUTING.md).
-   [X] Read the [Pull Request Guidelines](https://github.com/arclix/arclix-docs/blob/master/CONTRIBUTING.md#pull-request-guidelines) and follow the [PR Title Convention](https://github.com/arclix/arclix-docs/blob/master/.github/COMMIT_CONVENTION.md).
-   [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
-   [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
-   [X] Ideally, include relevant tests that fail without this PR but pass with it.
